### PR TITLE
new equation in czm_alphaWeight shader function

### DIFF
--- a/Source/Shaders/Builtin/Functions/alphaWeight.glsl
+++ b/Source/Shaders/Builtin/Functions/alphaWeight.glsl
@@ -27,6 +27,6 @@ float czm_alphaWeight(float a)
     }
 
     // See Weighted Blended Order-Independent Transparency for examples of different weighting functions:
-    // http://jcgt.org/published/0002/02/09/
-    return pow(a + 0.01, 4.0) + max(1e-2, min(3.0 * 1e3, 100.0 / (1e-5 + pow(abs(z) / 10.0, 3.0) + pow(abs(z) / 200.0, 6.0))));
+    // http://jcgt.org/published/0002/02/09/    
+    return pow(a + 0.01, 4.0) + max(1e-2, min(3.0 * 1e3, 0.003 / (1e-5 + pow(abs(z) / 200.0, 4.0))));
 }


### PR DESCRIPTION
using equation (9) from  paper http://jcgt.org/published/0002/02/09/   
in shader function czm_alphaWeight
Better suited for massive tree data sets with transparent textures